### PR TITLE
Changes to UI manager, SkillTreeManager and PauseGame

### DIFF
--- a/Assets/Scenes/PersistentGameplay.unity
+++ b/Assets/Scenes/PersistentGameplay.unity
@@ -2659,11 +2659,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::UIManager
   playerHealthSystem: {fileID: 3151644542123515065}
   inputReader: {fileID: 4840740199277927160}
-  healthBarRoot: {fileID: 0}
-  scoreRoot: {fileID: 0}
+  healthBarRoot: {fileID: 84472324}
+  scoreRoot: {fileID: 5816876495010797013}
   healthBar: {fileID: 2205497}
   pausePanel: {fileID: 2753566161430921809}
   gameOverPanel: {fileID: 0}
+  skillTreePanel: {fileID: 1010265767}
 --- !u!1 &1671242515
 GameObject:
   m_ObjectHideFlags: 0
@@ -3505,7 +3506,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &2117609135
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4436,7 +4437,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::TileDigger
   grid: {fileID: 0}
   tilemaps: []
-  offsetMultiplier: 1.1
+  digDistance: 0.8
+  useWideDig: 0
 --- !u!1 &5977944840149022734
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Room_3.unity
+++ b/Assets/Scenes/Room_3.unity
@@ -697,6 +697,10 @@ PrefabInstance:
       propertyPath: m_Color.g
       value: 0.26249632
       objectReference: {fileID: 0}
+    - target: {fileID: 2118492639261662656, guid: 0ba2599a63e4e5f488d1754bff850953, type: 3}
+      propertyPath: m_SortingOrder
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2904997712983297670, guid: 0ba2599a63e4e5f488d1754bff850953, type: 3}
       propertyPath: m_Name
       value: Ground

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -4,7 +4,7 @@ public class GameManager : MonoBehaviour
 {
     public static GameManager I { get; private set; }
 
-    public enum GameState { Play, Pause, GameOver }
+    public enum GameState { Play, Pause, SkillTree, GameOver }
 
     [SerializeField] private GameState state = GameState.Play;
     public GameState State => state;

--- a/Assets/Scripts/Core/SkillTreeManager.cs
+++ b/Assets/Scripts/Core/SkillTreeManager.cs
@@ -17,8 +17,6 @@ public class SkillTreeManager : MonoBehaviour
     [Header("Data")]
     public int playerSkillPoints = 10;
 
-    private bool isOpen;
-
     private void Awake()
     {
         if (instance == null) instance = this;
@@ -49,11 +47,6 @@ public class SkillTreeManager : MonoBehaviour
             skillTreeWindow.SetActive(false);
     }
 
-    private void Update()
-    {
-
-    }
-
     private void ToggleWindow()
     {
         if (GameManager.I == null) return;
@@ -62,18 +55,10 @@ public class SkillTreeManager : MonoBehaviour
 
         if (skillTreeWindow == null) return;
 
-        isOpen = !isOpen;
-        skillTreeWindow.SetActive(isOpen);
-
-        if (isOpen)
-        {
-            GameManager.I.PauseGame();
-            UpdateUI();
-        }
-        else
-        {
+        if (GameManager.I.State == GameManager.GameState.Pause)
             GameManager.I.ResumeGame();
-        }
+        else
+            GameManager.I.PauseGame();
     }
 
     private void ResetSkills()

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -17,6 +17,7 @@ public class UIManager : MonoBehaviour
     [Header("Screens")]
     [SerializeField] private GameObject pausePanel;
     [SerializeField] private GameObject gameOverPanel;
+    [SerializeField] private GameObject skillTreePanel;
 
     private void Awake()
     {
@@ -54,20 +55,10 @@ public class UIManager : MonoBehaviour
 
     private void HandleGameStateChanged(GameManager.GameState state)
     {
-        bool isPlay = (state == GameManager.GameState.Play);
-        bool isSkillTreeOpen = SkillTreeManager.instance != null &&
-                               SkillTreeManager.instance.skillTreeWindow != null &&
-                               SkillTreeManager.instance.skillTreeWindow.activeSelf;
-
-        if (healthBarRoot) healthBarRoot.SetActive(isPlay);
-
-        if (scoreRoot) scoreRoot.SetActive(isPlay || isSkillTreeOpen);
-
-        if (pausePanel)
-            pausePanel.SetActive(state == GameManager.GameState.Pause && !isSkillTreeOpen);
-
-        if (gameOverPanel)
-            gameOverPanel.SetActive(state == GameManager.GameState.GameOver);
+        if (healthBarRoot) healthBarRoot.SetActive(state == GameManager.GameState.Play);
+        if (pausePanel) pausePanel.SetActive(state == GameManager.GameState.Pause);
+        if (skillTreePanel) skillTreePanel.SetActive(state == GameManager.GameState.SkillTree);
+        if (gameOverPanel) gameOverPanel.SetActive(state == GameManager.GameState.GameOver);
     }
 
     public void UpdateHealthUI(float currentHealth, float maxHealth)

--- a/Assets/Scripts/UI/pauseGame.cs
+++ b/Assets/Scripts/UI/pauseGame.cs
@@ -13,7 +13,7 @@ public class PauseGame : MonoBehaviour
 
     public void OnQuitToMenu()
     {
-        Time.timeScale = 1f;
+        GameManager.I?.ResumeGame();
         SceneManager.LoadScene("MainMenu"); 
     }
 }


### PR DESCRIPTION
changes I made:
- skill tree manager was still doing ui management. removed skillTreeWindow.SetActive() and isOpen, moved skill tree panel to ui manager.
- pause game script touched time scale directly (only game manager should). I replaced time scale with resume game.
- I don't think ui manager should check skill tree manager to decide what to show, so I made skill tree its own game state.